### PR TITLE
API-402: Add last resort CSV decoder for slice types

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -5,11 +5,10 @@
 package schema
 
 import (
-	"bytes"
-	"encoding/csv"
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // NewDecoder returns a new Decoder.
@@ -158,29 +157,27 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart,
 				}
 				items = append(items, item)
 			} else {
-				//Try CSV
-				reader := csv.NewReader(bytes.NewBufferString(value))
-				values, err := reader.Read() //Reads one record/line
-				if err != nil {              //Not CSV
-					// If a single value is invalid should we give up
-					// or set a zero value?
-					return ConversionError{path, key}
-				}
-				for _, value := range values {
-					if value == "" {
-						if d.zeroEmpty {
-							items = append(items, reflect.Zero(elemT))
+				if strings.Contains(value, ",") {
+					values := strings.Split(value, ",")
+					for _, value := range values {
+						if value == "" {
+							if d.zeroEmpty {
+								items = append(items, reflect.Zero(elemT))
+							}
+						} else if item := conv(value); item.IsValid() {
+							if isPtrElem {
+								ptr := reflect.New(elemT)
+								ptr.Elem().Set(item)
+								item = ptr
+							}
+							items = append(items, item)
+						} else {
+							return ConversionError{path, key}
 						}
-					} else if item := conv(value); item.IsValid() {
-						if isPtrElem {
-							ptr := reflect.New(elemT)
-							ptr.Elem().Set(item)
-							item = ptr
-						}
-						items = append(items, item)
-					} else {
-						return ConversionError{path, key}
 					}
+
+				} else {
+					return ConversionError{path, key}
 				}
 			}
 		}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1036,3 +1036,44 @@ func TestAllNT(t *testing.T) {
 		}
 	}
 }
+
+// ----------------------------------------------------------------------------
+
+type S12A struct {
+	ID []int
+}
+
+func TestCSVSlice(t *testing.T) {
+	data := map[string][]string{
+		"ID": {"0,1"},
+	}
+
+	s := S12A{}
+	NewDecoder().Decode(&s, data)
+	if len(s.ID) != 2 {
+		t.Errorf("Expected two values in the result list, got %+v", s.ID)
+	}
+	if s.ID[0] != 0 || s.ID[1] != 1 {
+		t.Errorf("Expected []{0, 1} got %+v", s)
+	}
+}
+
+type S12B struct {
+	ID []string
+}
+
+//Decode should not split on , into a slice for string only
+func TestCSVStringSlice(t *testing.T) {
+	data := map[string][]string{
+		"ID": {"0,1"},
+	}
+
+	s := S12B{}
+	NewDecoder().Decode(&s, data)
+	if len(s.ID) != 1 {
+		t.Errorf("Expected one value in the result list, got %+v", s.ID)
+	}
+	if s.ID[0] != "0,1" {
+		t.Errorf("Expected []{0, 1} got %+v", s)
+	}
+}


### PR DESCRIPTION
This should work for most array types.  The only issue
I can think of off hand is the []string type.  Do we want to
break &foo=a,b,c&foo=d into ["a","b","c","d"] or ["a,b,c", "d"]?
For now that is the second option which should not break any
backwards compatability

I also submitted this pr to upstream gorilla/schema
